### PR TITLE
[Bugfix] mars weather when no data is available for a day

### DIFF
--- a/duckbot/weather.py
+++ b/duckbot/weather.py
@@ -58,12 +58,24 @@ def parse_earth_date(v: str) -> date:
     return date(year=parts[0], month=parts[1], day=parts[2])
 
 
+def has_temp_data(v: WeatherReport):
+    return v.min_temp is not None and v.max_temp is not None
+
+
 @alru_cache(ttl=21600.0)
 async def latest_mars_weather() -> WeatherReport:
     d1 = await get_mars_weather(URL_PERSERVERENCE)
     d2 = await get_mars_weather(URL_CURIOSITY)
-    w1 = convert_feed_item(d1[0])
-    w2 = convert_feed_item(d2[0])
+
+    d1 = [convert_feed_item(x) for x in d1]
+    d1 = [x for x in d1 if has_temp_data(x)]
+
+    d2 = [convert_feed_item(x) for x in d2]
+    d2 = [x for x in d2 if has_temp_data(x)]
+
+    w1 = d1[0]
+    w2 = d2[0]
+
     # Pick the latest report, with a preference towards Curiosity
     if parse_earth_date(w2.earth_date) >= parse_earth_date(w1.earth_date):
         return w2

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -89,13 +89,13 @@ async def test_ping_command():
 
 
 @pytest.mark.asyncio
-@patch('duckbot.weather.latest_mars_weather')
+@patch('duckbot.cmd.latest_mars_weather')
 async def test_weather_command_mars(latest_mars_weather):
     ctx = Mock(name='ctx', channel=AsyncMock())
     ctx.args = ['mars']
     latest_mars_weather.return_value = weather.WeatherReport(earth_date='2000-01-01', sol=123, min_temp=-100.0, max_temp=-10.0, atmosphere='Sunny', uv_index='Low')
     await cmd.weather_command(ctx)
-    ctx.channel.send.assert_called_once_with('🪐 Mars weather on `2023-08-21`. Min: `-79.0` Max: `-21.0` Atmosphere: `Sunny` UV: `Moderate`')
+    ctx.channel.send.assert_called_once_with('🪐 Mars weather on `2000-01-01`. Min: `-100.0` Max: `-10.0` Atmosphere: `Sunny` UV: `Low`')
 
 
 @pytest.mark.asyncio

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock, MagicMock, AsyncMock, patch, call, ANY
+
+import pytest
+
+from duckbot import weather
+
+
+@pytest.mark.asyncio
+async def test_latest_mars_weather_prefers_curiosity():
+    perserverence_reports = [
+        {
+            'terrestrial_date': '2000-01-01',
+            'sol': '1',
+            'min_temp': '-100',
+            'max_temp': '-10',
+        }
+    ]
+    curiosity_reports = [
+        {
+            'terrestrial_date': '2000-01-01',
+            'sol': '2',
+            'min_temp': '-200',
+            'max_temp': '-100',
+        }
+    ]
+
+    with patch('duckbot.weather.get_mars_weather', side_effect=[perserverence_reports, curiosity_reports]):
+        w = await weather.latest_mars_weather()
+
+    assert w.earth_date == '2000-01-01'
+    assert w.sol == 2
+    assert w.min_temp == -200
+    assert w.max_temp == -100
+
+
+@pytest.mark.asyncio
+async def test_latest_mars_weather_filters_empty_data():
+    perserverence_reports = [
+        {
+            'terrestrial_date': '2000-01-02',
+            'sol': '1',
+            'min_temp': '-100',
+            'max_temp': '-10',
+        }
+    ]
+    curiosity_reports = [
+        {
+            'terrestrial_date': '2000-01-02',
+            'sol': '2',
+            'min_temp': '--',
+            'max_temp': '--',
+        },
+        {
+            'terrestrial_date': '2000-01-01',
+            'sol': '2',
+            'min_temp': '-200',
+            'max_temp': '-100',
+        }
+    ]
+
+    with patch('duckbot.weather.get_mars_weather', side_effect=[perserverence_reports, curiosity_reports]):
+        w = await weather.latest_mars_weather()
+
+    assert w.earth_date == '2000-01-02'
+    assert w.sol == 1


### PR DESCRIPTION
Filter empty data so that `latest_mars_weather` will actually return a weathe report with data.